### PR TITLE
Mark helper functions static inline

### DIFF
--- a/bcdec.h
+++ b/bcdec.h
@@ -90,7 +90,7 @@ void bcdec_bc7(const void* compressedBlock, void* decompressedBlock, int destina
 
 #ifdef BCDEC_IMPLEMENTATION
 
-void bcdec__color_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int onlyOpaqueMode) {
+static inline void bcdec__color_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int onlyOpaqueMode) {
     unsigned short c0, c1;
     unsigned int refColors[4]; /* 0xAABBGGRR */
     unsigned char* dstColors;
@@ -150,7 +150,7 @@ void bcdec__color_block(const void* compressedBlock, void* decompressedBlock, in
     }
 }
 
-void bcdec__sharp_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+static inline void bcdec__sharp_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
     unsigned short* alpha;
     unsigned char* decompressed;
     int i, j;
@@ -167,7 +167,7 @@ void bcdec__sharp_alpha_block(const void* compressedBlock, void* decompressedBlo
     }
 }
 
-void bcdec__smooth_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int pixelSize) {
+static inline void bcdec__smooth_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int pixelSize) {
     unsigned char* decompressed;
     unsigned char alpha[8];
     int i, j;
@@ -214,7 +214,7 @@ typedef struct bcdec__bitstream {
     unsigned long long high;
 } bcdec__bitstream_t;
 
-int bcdec__bitstream_read_bits(bcdec__bitstream_t* bstream, int numBits) {
+static inline int bcdec__bitstream_read_bits(bcdec__bitstream_t* bstream, int numBits) {
     unsigned int mask = (1 << numBits) - 1;
     /* Read the low N bits */
     unsigned int bits = (bstream->low & mask);
@@ -227,13 +227,13 @@ int bcdec__bitstream_read_bits(bcdec__bitstream_t* bstream, int numBits) {
     return bits;
 }
 
-int bcdec__bitstream_read_bit(bcdec__bitstream_t* bstream) {
+static inline int bcdec__bitstream_read_bit(bcdec__bitstream_t* bstream) {
     return bcdec__bitstream_read_bits(bstream, 1);
 }
 
 /*  reversed bits pulling, used in BC6H decoding
     why ?? just why ??? */
-int bcdec__bitstream_read_bits_r(bcdec__bitstream_t* bstream, int numBits) {
+static inline int bcdec__bitstream_read_bits_r(bcdec__bitstream_t* bstream, int numBits) {
     int bits = bcdec__bitstream_read_bits(bstream, numBits);
     /* Reverse the bits. */
     int result = 0;
@@ -271,11 +271,11 @@ void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destina
 }
 
 /* http://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend */
-int bcdec__extend_sign(int val, int bits) {
+static inline int bcdec__extend_sign(int val, int bits) {
     return (val << (32 - bits)) >> (32 - bits);
 }
 
-int bcdec__transform_inverse(int val, int a0, int bits, int isSigned) {
+static inline int bcdec__transform_inverse(int val, int a0, int bits, int isSigned) {
     /* If the precision of A0 is "p" bits, then the transform algorithm is:
        B0 = (B0 + A0) & ((1 << p) - 1) */
     val = (val + a0) & ((1 << bits) - 1);
@@ -286,7 +286,7 @@ int bcdec__transform_inverse(int val, int a0, int bits, int isSigned) {
 }
 
 /* pretty much copy-paste from documentation */
-int bcdec__unquantize(int val, int bits, int isSigned) {
+static inline int bcdec__unquantize(int val, int bits, int isSigned) {
     int unq, s = 0;
 
     if (!isSigned) {
@@ -324,11 +324,11 @@ int bcdec__unquantize(int val, int bits, int isSigned) {
     return unq;
 }
 
-int bcdec__interpolate(int a, int b, int* weights, int index) {
+static inline int bcdec__interpolate(int a, int b, int* weights, int index) {
     return (a * (64 - weights[index]) + b * weights[index] + 32) >> 6;
 }
 
-unsigned short bcdec__finish_unquantize(int val, int isSigned) {
+static inline unsigned short bcdec__finish_unquantize(int val, int isSigned) {
     int s;
 
     if (!isSigned) {
@@ -345,7 +345,7 @@ unsigned short bcdec__finish_unquantize(int val, int isSigned) {
 }
 
 /* modified half_to_float_fast4 from https://gist.github.com/rygorous/2144712 */
-float bcdec__half_to_float_quick(unsigned short half) {
+static inline float bcdec__half_to_float_quick(unsigned short half) {
     typedef union {
         unsigned int u;
         float f;
@@ -901,7 +901,7 @@ void bcdec_bc6h_float(const void* compressedBlock, void* decompressedBlock, int 
     }
 }
 
-void bcdec__swap_values(int* a, int* b) {
+static inline void bcdec__swap_values(int* a, int* b) {
     a[0] ^= b[0], b[0] ^= a[0], a[0] ^= b[0];
 }
 


### PR DESCRIPTION
When built into a shared library, this prevents them from getting their own symbol, duplicating code that would otherwise get inlined into the actual entrypoints.

The gain is of about 4 KiB when built using gcc 12 on Linux.